### PR TITLE
Change papertrail lambda runtime to node 4.3

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -153,6 +153,7 @@ resource "aws_lambda_function" "papertrail" {
   handler = "index.handler"
   filename = "${module.papertrail.filepath}"
   timeout = 30
+  runtime = "nodejs4.3"
 
   role = "${aws_iam_role.function.arn}"
 


### PR DESCRIPTION
https://www.terraform.io/docs/providers/aws/r/lambda_function.html

https://docs.aws.amazon.com/lambda/latest/dg/API_CreateFunction.html#SSS-CreateFunction-request-Runtime
